### PR TITLE
Refactor CI with reusable setup action

### DIFF
--- a/.github/actions/setup-rdmo/action.yml
+++ b/.github/actions/setup-rdmo/action.yml
@@ -60,9 +60,15 @@ runs:
       shell: bash
       run: |
         sudo systemctl start mysql.service
-        sudo mysqladmin --protocol=socket --user=root status --silent
-        sudo mysql --protocol=socket --user=root --password='' --connect-expired-password --execute="ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root'; FLUSH PRIVILEGES;" \
-          || sudo mysql --protocol=socket --user=root --execute="ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root'; FLUSH PRIVILEGES;"
+        for i in $(seq 1 30); do
+          if sudo mysqladmin --protocol=socket --user=root ping --silent; then
+            ready=true
+            break
+          fi
+          sleep 1
+        done
+        [[ "${ready:-false}" == true ]] || { echo "MySQL did not become ready"; exit 1; }
+        sudo mysql --protocol=socket --user=root --execute="ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root'; FLUSH PRIVILEGES;" || true
         sudo mysql --protocol=tcp --user=root --password=root --execute="CREATE DATABASE IF NOT EXISTS rdmo CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
 
     - name: Start and prepare PostgreSQL

--- a/.github/actions/setup-rdmo/action.yml
+++ b/.github/actions/setup-rdmo/action.yml
@@ -1,0 +1,89 @@
+name: Setup RDMO environment
+
+inputs:
+  python-version:
+    description: Python version to install
+    required: true
+  db-backend:
+    description: Database backend (mysql or postgres)
+    required: true
+  wheel-extras:
+    description: Extras to install from the wheel
+    default: ci
+    required: false
+  install-wheel:
+    description: Whether to install the RDMO wheel
+    default: true
+    required: false
+  install-latex:
+    description: Whether to install LaTeX and pandoc dependencies
+    default: true
+    required: false
+  prepare-env:
+    description: Whether to prepare media and log folders
+    default: true
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v5
+      with:
+        persist-credentials: false
+
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: pip
+
+    - name: Download wheel
+      uses: actions/download-artifact@v6
+      with:
+        name: Packages
+        path: dist
+
+    - name: Install LaTeX and pandoc dependencies
+      if: ${{ inputs.install-latex == 'true' }}
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install --yes pandoc texlive-latex-base texlive-latex-extra texlive-luatex librsvg2-bin
+
+    - name: Upgrade pip
+      shell: bash
+      run: python -m pip install --upgrade pip
+
+    - name: Start and prepare MySQL
+      if: ${{ inputs.db-backend == 'mysql' }}
+      shell: bash
+      run: |
+        sudo systemctl start mysql.service
+        sudo mysql --protocol=socket --user=root --execute="ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';"
+        sudo mysql --protocol=tcp --user=root --password=root --execute="CREATE DATABASE IF NOT EXISTS rdmo CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+
+    - name: Start and prepare PostgreSQL
+      if: ${{ inputs.db-backend == 'postgres' }}
+      shell: bash
+      run: |
+        sudo systemctl start postgresql.service
+        pg_isready
+        sudo -u postgres psql --command="CREATE USER postgres_user PASSWORD 'postgres_password' CREATEDB" || true
+        sudo -u postgres psql --command="ALTER ROLE postgres_user CREATEDB" || true
+        sudo -u postgres psql --command="CREATE DATABASE rdmo OWNER postgres_user" || true
+
+    - name: Prepare environment folders
+      if: ${{ inputs.prepare-env == 'true' }}
+      shell: bash
+      run: |
+        cp -r testing/media testing/media_root
+        mkdir testing/log
+
+    - name: Install RDMO from wheel
+      if: ${{ inputs.install-wheel == 'true' }}
+      shell: bash
+      env:
+        GITHUB_DB_BACKEND: ${{ inputs.db-backend }}
+      run: |
+        python -m pip install "$(ls dist/*.whl)[${{ inputs.wheel-extras }}]"

--- a/.github/actions/setup-rdmo/action.yml
+++ b/.github/actions/setup-rdmo/action.yml
@@ -60,7 +60,9 @@ runs:
       shell: bash
       run: |
         sudo systemctl start mysql.service
-        sudo mysql --protocol=socket --user=root --execute="ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';"
+        sudo mysqladmin --protocol=socket --user=root status --silent
+        sudo mysql --protocol=socket --user=root --password='' --connect-expired-password --execute="ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root'; FLUSH PRIVILEGES;" \
+          || sudo mysql --protocol=socket --user=root --execute="ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root'; FLUSH PRIVILEGES;"
         sudo mysql --protocol=tcp --user=root --password=root --execute="CREATE DATABASE IF NOT EXISTS rdmo CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
 
     - name: Start and prepare PostgreSQL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,41 +56,15 @@ jobs:
       matrix:
         python-version: ['3.10', '3.13']
         db-backend: [mysql, postgres]
+    env:
+      GITHUB_DB_BACKEND: ${{ matrix.db-backend }}
     steps:
-    - uses: actions/checkout@v5
-      with:
-        persist-credentials: false
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+    - name: Set up environment
+      uses: ./.github/actions/setup-rdmo
       with:
         python-version: ${{ matrix.python-version }}
-        cache: pip
-    - name: Download wheel
-      uses: actions/download-artifact@v6
-      with:
-        name: Packages
-        path: dist
-    - name: Install Dependencies
-      run: |
-        sudo apt-get update && sudo apt-get install --yes pandoc texlive-latex-base texlive-latex-extra texlive-luatex librsvg2-bin
-        pandoc --version
-        python -m pip install --upgrade pip
-        python -m pip --version
-    - name: Install rdmo[mysql] from wheel and start mysql
-      run: |
-        python -m pip install "$(ls dist/*.whl)[ci,mysql]"
-        sudo systemctl start mysql.service
-      if: matrix.db-backend == 'mysql'
-    - name: Install rdmo[postgres] from wheel and start postgresql
-      run: |
-        python -m pip install "$(ls dist/*.whl)[ci,postgres]"
-        sudo systemctl start postgresql.service
-        pg_isready
-        sudo -u postgres psql --command="CREATE USER postgres_user PASSWORD 'postgres_password' CREATEDB"
-      if: matrix.db-backend == 'postgres'
-    - name: Prepare Env
-      run: |
-        cp -r testing/media testing/media_root && mkdir testing/log
+        db-backend: ${{ matrix.db-backend }}
+        wheel-extras: ci,${{ matrix.db-backend }}
     - name: Run package status tests first
       run: |
         pytest rdmo/core/tests/test_package_status.py --nomigrations --verbose
@@ -98,8 +72,6 @@ jobs:
     - name: Run Tests
       run: |
         pytest -p randomly -p no:cacheprovider --cov --reuse-db --numprocesses=auto --dist=loadscope
-      env:
-        GITHUB_DB_BACKEND: ${{ matrix.db-backend }}
     - name: Upload coverage data to coveralls.io
       uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
       with:
@@ -116,33 +88,15 @@ jobs:
       matrix:
         python-version: ['3.13']
         db-backend: [postgres]
+    env:
+      GITHUB_DB_BACKEND: ${{ matrix.db-backend }}
     steps:
-    - uses: actions/checkout@v5
-      with:
-        persist-credentials: false
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+    - name: Set up environment
+      uses: ./.github/actions/setup-rdmo
       with:
         python-version: ${{ matrix.python-version }}
-        cache: pip
-    - name: Download wheel
-      uses: actions/download-artifact@v6
-      with:
-        name: Packages
-        path: dist
-    - name: Install Dependencies
-      run: |
-        sudo apt-get update && sudo apt install --yes pandoc texlive-latex-base texlive-latex-extra texlive-luatex librsvg2-bin
-        python -m pip install --upgrade pip
-    - name: Install rdmo[postgres] from wheel and start postgresql
-      run: |
-        python -m pip install "$(ls dist/*.whl)[ci,postgres]"
-        sudo systemctl start postgresql.service
-        pg_isready
-        sudo -u postgres psql --command="CREATE USER postgres_user PASSWORD 'postgres_password' CREATEDB"
-    - name: Prepare Env
-      run: |
-        cp -r testing/media testing/media_root && mkdir testing/log
+        db-backend: ${{ matrix.db-backend }}
+        wheel-extras: ci,${{ matrix.db-backend }}
     - name: Install e2e tests dependencies
       run: |
         playwright install --with-deps chromium
@@ -158,6 +112,36 @@ jobs:
       with:
         name: screenshots
         path: screenshots/**/*.png
+
+  migrations-upgrade:
+    name: "Migrations upgrade check (${{ matrix.db-backend }})"
+    needs: build-wheel
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        db-backend: [mysql, postgres]
+    env:
+      GITHUB_DB_BACKEND: ${{ matrix.db-backend }}
+    steps:
+      - name: Set up environment
+        uses: ./.github/actions/setup-rdmo
+        with:
+          python-version: "3.13"
+          db-backend: ${{ matrix.db-backend }}
+          install-wheel: false
+          wheel-extras: ci,${{ matrix.db-backend }}
+      - name: Install rdmo main branch
+        run: |
+          python -m pip install "rdmo[ci,${{ matrix.db-backend }}] @ git+https://github.com/rdmorganiser/rdmo@main"
+      - name: Apply migrations for main branch
+        run: |
+          python testing/manage.py migrate
+      - name: Install rdmo from current branch
+        run: |
+          python -m pip install --force-reinstall "$(ls dist/*.whl)[ci,${{ matrix.db-backend }}]"
+      - name: Run upgrade command
+        run: |
+          python testing/manage.py upgrade
 
   coveralls:
     name: Indicate completion to coveralls
@@ -251,6 +235,7 @@ jobs:
       - test
       - coveralls
       - test-e2e
+      - migrations-upgrade
       - dev-setup
       - dependencies
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
     env:
       GITHUB_DB_BACKEND: ${{ matrix.db-backend }}
     steps:
+    - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
     - name: Set up environment
       uses: ./.github/actions/setup-rdmo
       with:
@@ -91,6 +94,9 @@ jobs:
     env:
       GITHUB_DB_BACKEND: ${{ matrix.db-backend }}
     steps:
+    - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
     - name: Set up environment
       uses: ./.github/actions/setup-rdmo
       with:
@@ -123,6 +129,9 @@ jobs:
     env:
       GITHUB_DB_BACKEND: ${{ matrix.db-backend }}
     steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Set up environment
         uses: ./.github/actions/setup-rdmo
         with:


### PR DESCRIPTION
## Summary
- extract shared environment preparation into a composite action for wheel-based jobs
- simplify test, e2e, and migration upgrade workflows to reuse the shared setup
- keep migration rehearsal while reducing duplication in ci.yml

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6937da530c40832db42faf25b8121a13)