### PR TITLE
Add OptionSet plugins to API and management UI

### DIFF
--- a/rdmo/management/assets/js/actions/elementActions.js
+++ b/rdmo/management/assets/js/actions/elementActions.js
@@ -278,13 +278,14 @@ export function fetchElement(elementType, elementId, elementAction=null) {
             OptionsApi.fetchOptionSet(elementId),
             ConditionsApi.fetchConditions('index'),
             OptionsApi.fetchOptions('index'),
-            QuestionsApi.fetchQuestions('index')
-          ]).then(([element, conditions, options, questions]) => {
+            QuestionsApi.fetchQuestions('index'),
+            ConfigApi.fetchPlugins('index')
+          ]).then(([element, conditions, options, questions, plugins]) => {
             if (elementAction == 'copy') {
               delete element.questions
             }
             return {
-              element, conditions, options, questions
+              element, conditions, options, questions, plugins
             }
           })
         }
@@ -569,8 +570,9 @@ export function createElement(elementType, parent={}) {
         action = () => Promise.all([
           OptionsFactory.createOptionSet(getState().config, parent),
           OptionsApi.fetchOptions('index'),
-        ]).then(([element, options]) => ({
-            element, parent, options
+          ConfigApi.fetchPlugins('index'),
+        ]).then(([element, options, plugins]) => ({
+            element, parent, options, plugins
           }))
         break
 

--- a/rdmo/management/assets/js/components/edit/EditOptionSet.js
+++ b/rdmo/management/assets/js/components/edit/EditOptionSet.js
@@ -22,7 +22,7 @@ import useDeleteModal from '../../hooks/useDeleteModal'
 const EditOptionSet = ({ config, optionset, elements, elementActions }) => {
 
   const { sites, providers } = config
-  const { elementAction, parent, conditions, options } = elements
+  const { elementAction, parent, conditions, options, plugins } = elements
 
   const updateOptionSet = (key, value) => elementActions.updateElement(optionset, {[key]: value})
   const storeOptionSet = (back) => elementActions.storeElement('optionsets', optionset, elementAction, back)
@@ -37,6 +37,8 @@ const EditOptionSet = ({ config, optionset, elements, elementActions }) => {
   const [showDeleteModal, openDeleteModal, closeDeleteModal] = useDeleteModal()
 
   const info = <OptionSetInfo optionset={optionset} elements={elements} elementActions={elementActions} />
+
+  const optionsetPlugins = plugins.filter((plugin) => plugin.plugin_type === 'optionset_provider')
 
   return (
     <div className="panel panel-default panel-edit">
@@ -105,6 +107,9 @@ const EditOptionSet = ({ config, optionset, elements, elementActions }) => {
 
         <Select config={config} element={optionset} field="provider_key"
                 options={providers} onChange={updateOptionSet} />
+
+        <MultiSelect config={config} element={optionset} field="plugins" options={optionsetPlugins}
+                     addText={gettext('Add existing plugin')} onChange={updateOptionSet} />
 
         {get(config, 'settings.multisite') && <Select config={config} element={optionset} field="editors"
                                                       options={sites} onChange={updateOptionSet} isMulti />}

--- a/rdmo/management/assets/js/factories/OptionsFactory.js
+++ b/rdmo/management/assets/js/factories/OptionsFactory.js
@@ -8,6 +8,7 @@ class OptionsFactory {
       uri_prefix: config.settings.default_uri_prefix,
       questions: parent.question ? [parent.question.id] : [],
       editors: config.settings.multisite ? [siteId] : [],
+      plugins: []
     }
   }
 

--- a/rdmo/options/serializers/v1/optionset.py
+++ b/rdmo/options/serializers/v1/optionset.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
 
+from rdmo.config.constants import PLUGIN_TYPES
+from rdmo.config.models import Plugin
 from rdmo.core.serializers import (
     ElementModelSerializerMixin,
     ReadOnlyObjectPermissionSerializerMixin,
@@ -29,6 +31,11 @@ class OptionSetSerializer(ThroughModelSerializerMixin, ElementModelSerializerMix
 
     options = OptionSetOptionSerializer(source='optionset_options', read_only=False, required=False, many=True)
     questions = serializers.PrimaryKeyRelatedField(queryset=Question.objects.all(), required=False, many=True)
+    plugins = serializers.PrimaryKeyRelatedField(
+        queryset=Plugin.objects.filter(plugin_type=PLUGIN_TYPES.OPTIONSET_PROVIDER),
+        required=False,
+        many=True
+    )
 
     read_only = serializers.SerializerMethodField()
 
@@ -50,6 +57,7 @@ class OptionSetSerializer(ThroughModelSerializerMixin, ElementModelSerializerMix
             'options',
             'conditions',
             'questions',
+            'plugins',
             'editors',
             'read_only',
             'condition_uris',

--- a/rdmo/options/tests/test_viewset_optionsets.py
+++ b/rdmo/options/tests/test_viewset_optionsets.py
@@ -98,6 +98,16 @@ def test_detail(db, client, username, password):
         assert response.status_code == status_map['detail'][username], response.json()
 
 
+def test_detail_includes_plugins(db, client):
+    client.login(username='editor', password='editor')
+
+    instance = OptionSet.objects.get(uri_path='plugin')
+    url = reverse(urlnames['detail'], args=[instance.pk])
+    response = client.get(url)
+    assert response.status_code == status_map['detail']['editor'], response.json()
+    assert response.json().get('plugins') == [3]
+
+
 @pytest.mark.parametrize('username,password', users)
 def test_nested(db, client, username, password):
     client.login(username=username, password=password)
@@ -233,6 +243,7 @@ def test_update_m2m(db, client, username, password):
             'order': instance.order,
             'options': optionset_options,
             'conditions': conditions,
+            'plugins': [3],
         }
         response = client.put(url, data, content_type='application/json')
         assert response.status_code == status_map['update'][username], response.json()

--- a/rdmo/options/viewsets.py
+++ b/rdmo/options/viewsets.py
@@ -34,7 +34,8 @@ class OptionSetViewSet(ModelViewSet):
         'optionset_options__option',
         'conditions',
         'questions',
-        'editors'
+        'editors',
+        'plugins'
     )
 
     filter_backends = (SearchFilter, DjangoFilterBackend)


### PR DESCRIPTION
### Motivation

- Expose the `plugins` relation on `OptionSet` so optionset provider plugins can be persisted and edited. 
- Make plugin data available to the management UI when creating/editing option sets. 
- Prefetch plugins on the API viewset to avoid N+1 queries for optionset operations. 
- Add test coverage to ensure the `plugins` field is returned and can be updated.

### Description

- Added a `plugins` `PrimaryKeyRelatedField` to `OptionSetSerializer` filtered by `PLUGIN_TYPES.OPTIONSET_PROVIDER`. 
- Prefetched `plugins` in `OptionSetViewSet.queryset` so API responses include plugin relations efficiently. 
- Loaded plugins into optionset edit/create flows by fetching `ConfigApi.fetchPlugins('index')` in `elementActions` and added `plugins` to the element factory via `OptionsFactory.createOptionSet`. 
- Updated the management UI `EditOptionSet` to render a `MultiSelect` for `plugins` and filter available plugins by `plugin_type === 'optionset_provider'`. 
- Added test assertions in `rdmo/options/tests/test_viewset_optionsets.py` to check that `plugins` are included in the detail response and that `plugins` can be updated with the optionset.

### Testing

- Attempted to run `pytest rdmo/options/tests/test_viewset_optionsets.py` locally in the environment, but the run failed because Django settings are not configured in this environment. 
- No other automated test runs were executed here due to the same environment limitation. 
- The changes were linted and the codebase committed after the implementations were applied. 
- Manual inspection of modified files confirms the serializer, viewset, frontend, and test changes are in place.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695ff96dcac0832d97cfcb0b7e92e713)