### PR TITLE
Validate plugin python path on create when available

### DIFF
--- a/rdmo/config/validators.py
+++ b/rdmo/config/validators.py
@@ -35,8 +35,16 @@ class PluginPythonPathValidator(InstanceValidator):
                 'python_path': _("This path is not in the configured paths.")
             })
 
-        if self.instance and self.instance.available:
-            try:  # a double-check, maybe not needed
+        if self.instance:
+            if self.instance.available:
+                try:  # a double-check, maybe not needed
+                    import_string(data.get('python_path'))
+                except (ModuleNotFoundError, ImportError):
+                    self.raise_validation_error({
+                        'python_path': _("This path could not be not imported.")
+                    })
+        elif data.get('available', True):
+            try:
                 import_string(data.get('python_path'))
             except (ModuleNotFoundError, ImportError):
                 self.raise_validation_error({


### PR DESCRIPTION
### Motivation
- Ensure the plugin `python_path` is importable at creation time when the incoming data marks the plugin as available via `data.get('available', True)`.
- Previously the import check only ran for updates when `self.instance.available` was true, allowing invalid import paths to be created.

### Description
- Update `PluginPythonPathValidator.__call__` to determine availability from incoming `data` when `instance` is `None` and run the import check accordingly.
- Keep the existing update behavior by only running the import check for updates when `self.instance.available` is true.
- Use `import_string` and raise a validation error on `ImportError` or `ModuleNotFoundError` for invalid `python_path` values.
- Preserve the existing checks that validate `python_path` against `get_plugin_python_paths()` and error messages.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696563ca1ddc832dacfff7132fd201ea)