### PR TITLE
Guard parent element permissions in multisite serializers

### DIFF
--- a/rdmo/core/serializers.py
+++ b/rdmo/core/serializers.py
@@ -6,6 +6,7 @@ from django.core.validators import MaxLengthValidator
 from django.db.models import Max
 
 from rest_framework import serializers
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.utils import model_meta
 
 from rdmo.core.utils import get_language_warning, get_languages, markdown2html
@@ -74,7 +75,30 @@ class TranslationSerializerMixin:
 
 class ThroughModelSerializerMixin:
 
+    def validate(self, data):
+        data = super().validate(data)
+        self.check_parent_object_permissions(data)
+        return data
+
+    def check_parent_object_permissions(self, validated_data):
+        try:
+            self.Meta.parent_fields  # noqa: B018
+        except AttributeError:
+            return
+
+        request = self.context.get('request')
+        if request is None:
+            return
+
+        for field_name, _source_name, _target_name, _through_name in self.Meta.parent_fields:
+            for parent in validated_data.get(field_name) or []:
+                opts = parent._meta
+                permission = f'{opts.app_label}.change_{opts.model_name}_object'
+                if not request.user.has_perm(permission, parent):
+                    raise PermissionDenied()
+
     def create(self, validated_data):
+        self.check_parent_object_permissions(validated_data)
         parent_fields = self.get_parent_fields(validated_data)
         through_fields = self.get_through_fields(validated_data)
         instance = super().create(validated_data)
@@ -83,6 +107,7 @@ class ThroughModelSerializerMixin:
         return instance
 
     def update(self, instance, validated_data):
+        self.check_parent_object_permissions(validated_data)
         self.get_parent_fields(validated_data)
         through_fields = self.get_through_fields(validated_data)
         instance = super().update(instance, validated_data)

--- a/rdmo/questions/tests/test_viewset_page_multisite.py
+++ b/rdmo/questions/tests/test_viewset_page_multisite.py
@@ -120,7 +120,13 @@ def test_create_section(db, client, username, password):
                 'sections': [section.id]
             }
             response = client.post(url, data, content_type='application/json')
-            assert response.status_code == status_map['create'][username], response.json()
+            expected_status_code = status_map['create'][username]
+            if (
+                expected_status_code == 201
+                and not response.wsgi_request.user.has_perm('questions.change_section_object', section)
+            ):
+                expected_status_code = 403
+            assert response.status_code == expected_status_code, response.json()
 
             if response.status_code == 201:
                 new_instance = Page.objects.get(id=response.json().get('id'))

--- a/rdmo/questions/tests/test_viewset_question_multisite.py
+++ b/rdmo/questions/tests/test_viewset_question_multisite.py
@@ -121,7 +121,13 @@ def test_create_page(db, client, username, password):
                 'pages': [page.id]
             }
             response = client.post(url, data, content_type='application/json')
-            assert response.status_code == status_map['create'][username], response.json()
+            expected_status_code = status_map['create'][username]
+            if (
+                expected_status_code == 201
+                and not response.wsgi_request.user.has_perm('questions.change_page_object', page)
+            ):
+                expected_status_code = 403
+            assert response.status_code == expected_status_code, response.json()
 
             if response.status_code == 201:
                 new_instance = Question.objects.get(id=response.json().get('id'))
@@ -163,7 +169,13 @@ def test_create_questionset(db, client, username, password):
                 'questionsets': [questionset.id]
             }
             response = client.post(url, data, content_type='application/json')
-            assert response.status_code == status_map['create'][username], response.json()
+            expected_status_code = status_map['create'][username]
+            if (
+                expected_status_code == 201
+                and not response.wsgi_request.user.has_perm('questions.change_questionset_object', questionset)
+            ):
+                expected_status_code = 403
+            assert response.status_code == expected_status_code, response.json()
 
             if response.status_code == 201:
                 new_instance = Question.objects.get(id=response.json().get('id'))

--- a/rdmo/questions/tests/test_viewset_questionset_multisite.py
+++ b/rdmo/questions/tests/test_viewset_questionset_multisite.py
@@ -120,7 +120,13 @@ def test_create_page(db, client, username, password):
                 'pages': [page.id]
             }
             response = client.post(url, data, content_type='application/json')
-            assert response.status_code == status_map['create'][username], response.json()
+            expected_status_code = status_map['create'][username]
+            if (
+                expected_status_code == 201
+                and not response.wsgi_request.user.has_perm('questions.change_page_object', page)
+            ):
+                expected_status_code = 403
+            assert response.status_code == expected_status_code, response.json()
 
             if response.status_code == 201:
                 new_instance = QuestionSet.objects.get(id=response.json().get('id'))
@@ -156,7 +162,13 @@ def test_create_parent(db, client, username, password):
                 'parents': [parent.id]
             }
             response = client.post(url, data, content_type='application/json')
-            assert response.status_code == status_map['create'][username], response.json()
+            expected_status_code = status_map['create'][username]
+            if (
+                expected_status_code == 201
+                and not response.wsgi_request.user.has_perm('questions.change_questionset_object', parent)
+            ):
+                expected_status_code = 403
+            assert response.status_code == expected_status_code, response.json()
 
             if response.status_code == 201:
                 new_instance = QuestionSet.objects.get(id=response.json().get('id'))

--- a/rdmo/questions/tests/test_viewset_section_multisite.py
+++ b/rdmo/questions/tests/test_viewset_section_multisite.py
@@ -108,7 +108,13 @@ def test_create_catalog(db, client, username, password):
                 'catalogs': [catalog.id]
             }
             response = client.post(url, data, content_type='application/json')
-            assert response.status_code == status_map['create'][username], response.json()
+            expected_status_code = status_map['create'][username]
+            if (
+                expected_status_code == 201
+                and not response.wsgi_request.user.has_perm('questions.change_catalog_object', catalog)
+            ):
+                expected_status_code = 403
+            assert response.status_code == expected_status_code, response.json()
 
             if response.status_code == 201:
                 new_instance = Section.objects.get(id=response.json().get('id'))


### PR DESCRIPTION
### Motivation
- Prevent editors from creating or updating child elements that attach to parent elements (catalog/section/page/questionset) they are not permitted to change in multisite setups.

### Description
- Added `check_parent_object_permissions` to `ThroughModelSerializerMixin` in `rdmo/core/serializers.py` which checks `change_<model>_object` for each submitted parent and raises `PermissionDenied` when missing.
- Call the check from `validate`, and before `create` and `update` so parent permissions are enforced early and on save.
- Imported `PermissionDenied` from `rest_framework.exceptions` to signal forbidden parent attachments.
- Adjusted multisite tests (`rdmo/questions/tests/test_viewset_*.py`) to expect `403` when a user tries to create a child under a parent they cannot change, and reformatted a few long lines to satisfy linter rules.

### Testing
- Ran linter: `ruff check rdmo/core/serializers.py rdmo/questions/tests/test_viewset_section_multisite.py rdmo/questions/tests/test_viewset_page_multisite.py rdmo/questions/tests/test_viewset_questionset_multisite.py rdmo/questions/tests/test_viewset_question_multisite.py` and it passed.
- Ran targeted pytest cases for multisite create scenarios: `DJANGO_SETTINGS_MODULE=config.settings PYTHONPATH=.:testing pytest rdmo/questions/tests/test_viewset_section_multisite.py::test_create_catalog rdmo/questions/tests/test_viewset_page_multisite.py::test_create_section rdmo/questions/tests/test_viewset_questionset_multisite.py::test_create_page rdmo/questions/tests/test_viewset_questionset_multisite.py::test_create_parent rdmo/questions/tests/test_viewset_question_multisite.py::test_create_page rdmo/questions/tests/test_viewset_question_multisite.py::test_create_questionset -q` which ultimately resulted in all tests passing (72 passed).
- All automated checks performed in this run succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a18593f96f8832d9e4db067c3a9f8b0)