### PR TITLE
Prevent cross-site parent edits for question elements

### DIFF
--- a/rdmo/core/serializers.py
+++ b/rdmo/core/serializers.py
@@ -6,6 +6,7 @@ from django.core.validators import MaxLengthValidator
 from django.db.models import Max
 
 from rest_framework import serializers
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.utils import model_meta
 
 from rdmo.core.utils import get_language_warning, get_languages, markdown2html
@@ -73,6 +74,38 @@ class TranslationSerializerMixin:
 
 
 class ThroughModelSerializerMixin:
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        self.validate_parent_field_permissions(attrs)
+        return attrs
+
+    def validate_parent_field_permissions(self, attrs):
+        try:
+            parent_fields = self.Meta.parent_fields
+        except AttributeError:
+            return
+
+        # Parent fields create through-model rows on existing parent elements when this
+        # serializer creates a new child element.  That effectively changes the
+        # parent element (for example adding a section to an existing catalog), so
+        # require object-level change permission for each supplied parent.
+        if self.instance is not None:
+            return
+
+        request = self.context.get('request')
+        if request is None:
+            return
+
+        for field_name, _source_name, _target_name, _through_name in parent_fields:
+            parents = attrs.get(field_name)
+            if parents is None:
+                continue
+
+            for parent in parents:
+                perm = f'{parent._meta.app_label}.change_{parent._meta.model_name}_object'
+                if not request.user.has_perm(perm, parent):
+                    raise PermissionDenied()
 
     def create(self, validated_data):
         parent_fields = self.get_parent_fields(validated_data)

--- a/rdmo/core/tests/constants.py
+++ b/rdmo/core/tests/constants.py
@@ -24,6 +24,12 @@ multisite_status_map = {
         'user': 403, 'example-reviewer': 403, 'example-editor': 201,
         'anonymous': 401, 'reviewer': 403, 'editor': 201,
     },
+    'create-parent': {
+        'foo-user': 403, 'foo-reviewer': 403, 'foo-editor': 403,
+        'bar-user': 403, 'bar-reviewer': 403, 'bar-editor': 403,
+        'user': 403, 'example-reviewer': 403, 'example-editor': 201,
+        'anonymous': 401, 'reviewer': 403, 'editor': 201,
+    },
     'copy': {
         'foo-user': 404, 'foo-reviewer': 403, 'foo-editor': 201,
         'bar-user': 404, 'bar-reviewer': 403, 'bar-editor': 201,
@@ -109,6 +115,18 @@ status_map_object_permissions = {
             'foo-reviewer': 404, 'foo-editor': 404,
             'bar-reviewer': 404, 'bar-editor': 404,
             'example-reviewer': 200, 'example-editor': 200,
+        }
+    },
+    'create-parent': {
+        'foo-element': {
+            'foo-reviewer': 403, 'foo-editor': 403,
+            'bar-reviewer': 403, 'bar-editor': 403,
+            'example-reviewer': 403, 'example-editor': 403,
+        },
+        'bar-element': {
+            'foo-reviewer': 403, 'foo-editor': 403,
+            'bar-reviewer': 403, 'bar-editor': 403,
+            'example-reviewer': 403, 'example-editor': 403,
         }
     },
     'update': {

--- a/rdmo/questions/serializers/v1/question.py
+++ b/rdmo/questions/serializers/v1/question.py
@@ -98,6 +98,7 @@ class QuestionSerializer(ThroughModelSerializerMixin, TranslationSerializerMixin
         return super().to_internal_value(data)
 
     def validate(self, data):
+        data = super().validate(data)
         is_collection = data.get('is_collection')
         widget_type = data.get('widget_type')
         value_type = data.get('value_type')

--- a/rdmo/questions/tests/test_viewset_page_multisite.py
+++ b/rdmo/questions/tests/test_viewset_page_multisite.py
@@ -2,7 +2,6 @@ import xml.etree.ElementTree as et
 
 import pytest
 
-from django.contrib.auth.models import User
 from django.db.models import Max
 from django.urls import reverse
 
@@ -121,12 +120,9 @@ def test_create_section(db, client, username, password):
                 'sections': [section.id]
             }
             response = client.post(url, data, content_type='application/json')
-            expected_status_code = status_map['create'][username]
-            if expected_status_code == 201 and not User.objects.get(username=username).has_perm(
-                'questions.change_section_object', section
-            ):
-                expected_status_code = 403
-            assert response.status_code == expected_status_code, response.json()
+            assert response.status_code == get_obj_perms_status_code(
+                section, username, 'create-parent'
+            ), response.json()
 
             if response.status_code == 201:
                 new_instance = Page.objects.get(id=response.json().get('id'))

--- a/rdmo/questions/tests/test_viewset_page_multisite.py
+++ b/rdmo/questions/tests/test_viewset_page_multisite.py
@@ -2,6 +2,7 @@ import xml.etree.ElementTree as et
 
 import pytest
 
+from django.contrib.auth.models import User
 from django.db.models import Max
 from django.urls import reverse
 
@@ -120,7 +121,12 @@ def test_create_section(db, client, username, password):
                 'sections': [section.id]
             }
             response = client.post(url, data, content_type='application/json')
-            assert response.status_code == status_map['create'][username], response.json()
+            expected_status_code = status_map['create'][username]
+            if expected_status_code == 201 and not User.objects.get(username=username).has_perm(
+                'questions.change_section_object', section
+            ):
+                expected_status_code = 403
+            assert response.status_code == expected_status_code, response.json()
 
             if response.status_code == 201:
                 new_instance = Page.objects.get(id=response.json().get('id'))

--- a/rdmo/questions/tests/test_viewset_parent_permissions_multisite.py
+++ b/rdmo/questions/tests/test_viewset_parent_permissions_multisite.py
@@ -1,0 +1,117 @@
+import pytest
+
+from django.contrib.sites.models import Site
+from django.urls import reverse
+
+from ..models import Catalog, Page, Question, QuestionSet, Section
+
+
+@pytest.mark.parametrize('model,parent_model,urlname,payload_builder', [
+    (
+        Section, Catalog, 'v1-questions:section-list',
+        lambda instance, parent: {
+            'uri_prefix': 'https://bar.com/terms',
+            'uri_path': f'{instance.uri_path}-bar-parent-denied',
+            'comment': instance.comment,
+            'title_en': instance.title_lang1,
+            'title_de': instance.title_lang2,
+            'catalogs': [parent.id]
+        }
+    ),
+    (
+        Page, Section, 'v1-questions:page-list',
+        lambda instance, parent: {
+            'uri_prefix': 'https://bar.com/terms',
+            'uri_path': f'{instance.uri_path}-bar-parent-denied',
+            'comment': instance.comment,
+            'attribute': instance.attribute_id,
+            'is_collection': instance.is_collection,
+            'title_en': instance.title_lang1,
+            'title_de': instance.title_lang2,
+            'sections': [parent.id]
+        }
+    ),
+    (
+        QuestionSet, Page, 'v1-questions:questionset-list',
+        lambda instance, parent: {
+            'uri_prefix': 'https://bar.com/terms',
+            'uri_path': f'{instance.uri_path}-bar-parent-denied',
+            'comment': instance.comment,
+            'attribute': instance.attribute_id,
+            'is_collection': instance.is_collection,
+            'title_en': instance.title_lang1,
+            'title_de': instance.title_lang2,
+            'pages': [parent.id]
+        }
+    ),
+    (
+        QuestionSet, QuestionSet, 'v1-questions:questionset-list',
+        lambda instance, parent: {
+            'uri_prefix': 'https://bar.com/terms',
+            'uri_path': f'{instance.uri_path}-bar-parent-denied-parent',
+            'comment': instance.comment,
+            'attribute': instance.attribute_id,
+            'is_collection': instance.is_collection,
+            'title_en': instance.title_lang1,
+            'title_de': instance.title_lang2,
+            'parents': [parent.id]
+        }
+    ),
+    (
+        Question, Page, 'v1-questions:question-list',
+        lambda instance, parent: {
+            'uri_prefix': 'https://bar.com/terms',
+            'uri_path': f'{instance.uri_path}-bar-parent-denied',
+            'comment': instance.comment,
+            'attribute': instance.attribute_id,
+            'is_collection': instance.is_collection,
+            'is_optional': instance.is_optional,
+            'widget_type': instance.widget_type,
+            'value_type': instance.value_type,
+            'text_en': instance.text_lang1,
+            'text_de': instance.text_lang2,
+            'pages': [parent.id]
+        }
+    ),
+    (
+        Question, QuestionSet, 'v1-questions:question-list',
+        lambda instance, parent: {
+            'uri_prefix': 'https://bar.com/terms',
+            'uri_path': f'{instance.uri_path}-bar-parent-denied-questionset',
+            'comment': instance.comment,
+            'attribute': instance.attribute_id,
+            'is_collection': instance.is_collection,
+            'is_optional': instance.is_optional,
+            'widget_type': instance.widget_type,
+            'value_type': instance.value_type,
+            'text_en': instance.text_lang1,
+            'text_de': instance.text_lang2,
+            'questionsets': [parent.id]
+        }
+    ),
+])
+def test_bar_editor_cannot_create_child_on_foo_parent(
+    db, client, settings, model, parent_model, urlname, payload_builder
+):
+    settings.SITE_ID = Site.objects.get(domain='bar.com').id
+    Site.objects.clear_cache()
+    client.login(username='bar-editor', password='bar-editor')
+
+    parent = parent_model.objects.get(uri_path=f'foo-{parent_model._meta.model_name}')
+    instance = model.objects.filter(uri_path=f'foo-{model._meta.model_name}').first()
+    if instance is None and model == QuestionSet:
+        instance = model.objects.get(uri_path='foo-questionset')
+    if instance is None and model == Question:
+        instance = model.objects.get(uri_path='foo-question')
+
+    through_name = {
+        Catalog: 'catalog_sections',
+        Section: 'section_pages',
+        Page: 'page_questionsets' if model == QuestionSet else 'page_questions',
+        QuestionSet: 'questionset_questionsets' if model == QuestionSet else 'questionset_questions',
+    }[parent_model]
+    before_count = getattr(parent, through_name).count()
+    response = client.post(reverse(urlname), payload_builder(instance, parent), content_type='application/json')
+
+    assert response.status_code == 403, response.json()
+    assert getattr(parent, through_name).count() == before_count

--- a/rdmo/questions/tests/test_viewset_parent_permissions_multisite.py
+++ b/rdmo/questions/tests/test_viewset_parent_permissions_multisite.py
@@ -3,6 +3,8 @@ import pytest
 from django.contrib.sites.models import Site
 from django.urls import reverse
 
+from rdmo.core.tests.constants import status_map_object_permissions as status_map
+
 from ..models import Catalog, Page, Question, QuestionSet, Section
 
 
@@ -113,5 +115,5 @@ def test_bar_editor_cannot_create_child_on_foo_parent(
     before_count = getattr(parent, through_name).count()
     response = client.post(reverse(urlname), payload_builder(instance, parent), content_type='application/json')
 
-    assert response.status_code == 403, response.json()
+    assert response.status_code == status_map['create-parent']['foo-element']['bar-editor'], response.json()
     assert getattr(parent, through_name).count() == before_count

--- a/rdmo/questions/tests/test_viewset_question_multisite.py
+++ b/rdmo/questions/tests/test_viewset_question_multisite.py
@@ -2,7 +2,6 @@ import xml.etree.ElementTree as et
 
 import pytest
 
-from django.contrib.auth.models import User
 from django.db.models import Max
 from django.urls import reverse
 
@@ -122,12 +121,9 @@ def test_create_page(db, client, username, password):
                 'pages': [page.id]
             }
             response = client.post(url, data, content_type='application/json')
-            expected_status_code = status_map['create'][username]
-            if expected_status_code == 201 and not User.objects.get(username=username).has_perm(
-                'questions.change_page_object', page
-            ):
-                expected_status_code = 403
-            assert response.status_code == expected_status_code, response.json()
+            assert response.status_code == get_obj_perms_status_code(
+                page, username, 'create-parent'
+            ), response.json()
 
             if response.status_code == 201:
                 new_instance = Question.objects.get(id=response.json().get('id'))
@@ -169,12 +165,9 @@ def test_create_questionset(db, client, username, password):
                 'questionsets': [questionset.id]
             }
             response = client.post(url, data, content_type='application/json')
-            expected_status_code = status_map['create'][username]
-            if expected_status_code == 201 and not User.objects.get(username=username).has_perm(
-                'questions.change_questionset_object', questionset
-            ):
-                expected_status_code = 403
-            assert response.status_code == expected_status_code, response.json()
+            assert response.status_code == get_obj_perms_status_code(
+                questionset, username, 'create-parent'
+            ), response.json()
 
             if response.status_code == 201:
                 new_instance = Question.objects.get(id=response.json().get('id'))

--- a/rdmo/questions/tests/test_viewset_question_multisite.py
+++ b/rdmo/questions/tests/test_viewset_question_multisite.py
@@ -2,6 +2,7 @@ import xml.etree.ElementTree as et
 
 import pytest
 
+from django.contrib.auth.models import User
 from django.db.models import Max
 from django.urls import reverse
 
@@ -121,7 +122,12 @@ def test_create_page(db, client, username, password):
                 'pages': [page.id]
             }
             response = client.post(url, data, content_type='application/json')
-            assert response.status_code == status_map['create'][username], response.json()
+            expected_status_code = status_map['create'][username]
+            if expected_status_code == 201 and not User.objects.get(username=username).has_perm(
+                'questions.change_page_object', page
+            ):
+                expected_status_code = 403
+            assert response.status_code == expected_status_code, response.json()
 
             if response.status_code == 201:
                 new_instance = Question.objects.get(id=response.json().get('id'))
@@ -163,7 +169,12 @@ def test_create_questionset(db, client, username, password):
                 'questionsets': [questionset.id]
             }
             response = client.post(url, data, content_type='application/json')
-            assert response.status_code == status_map['create'][username], response.json()
+            expected_status_code = status_map['create'][username]
+            if expected_status_code == 201 and not User.objects.get(username=username).has_perm(
+                'questions.change_questionset_object', questionset
+            ):
+                expected_status_code = 403
+            assert response.status_code == expected_status_code, response.json()
 
             if response.status_code == 201:
                 new_instance = Question.objects.get(id=response.json().get('id'))

--- a/rdmo/questions/tests/test_viewset_questionset_multisite.py
+++ b/rdmo/questions/tests/test_viewset_questionset_multisite.py
@@ -2,6 +2,7 @@ import xml.etree.ElementTree as et
 
 import pytest
 
+from django.contrib.auth.models import User
 from django.db.models import Max
 from django.urls import reverse
 
@@ -120,7 +121,12 @@ def test_create_page(db, client, username, password):
                 'pages': [page.id]
             }
             response = client.post(url, data, content_type='application/json')
-            assert response.status_code == status_map['create'][username], response.json()
+            expected_status_code = status_map['create'][username]
+            if expected_status_code == 201 and not User.objects.get(username=username).has_perm(
+                'questions.change_page_object', page
+            ):
+                expected_status_code = 403
+            assert response.status_code == expected_status_code, response.json()
 
             if response.status_code == 201:
                 new_instance = QuestionSet.objects.get(id=response.json().get('id'))

--- a/rdmo/questions/tests/test_viewset_questionset_multisite.py
+++ b/rdmo/questions/tests/test_viewset_questionset_multisite.py
@@ -2,7 +2,6 @@ import xml.etree.ElementTree as et
 
 import pytest
 
-from django.contrib.auth.models import User
 from django.db.models import Max
 from django.urls import reverse
 
@@ -121,12 +120,9 @@ def test_create_page(db, client, username, password):
                 'pages': [page.id]
             }
             response = client.post(url, data, content_type='application/json')
-            expected_status_code = status_map['create'][username]
-            if expected_status_code == 201 and not User.objects.get(username=username).has_perm(
-                'questions.change_page_object', page
-            ):
-                expected_status_code = 403
-            assert response.status_code == expected_status_code, response.json()
+            assert response.status_code == get_obj_perms_status_code(
+                page, username, 'create-parent'
+            ), response.json()
 
             if response.status_code == 201:
                 new_instance = QuestionSet.objects.get(id=response.json().get('id'))

--- a/rdmo/questions/tests/test_viewset_section_multisite.py
+++ b/rdmo/questions/tests/test_viewset_section_multisite.py
@@ -2,6 +2,7 @@ import xml.etree.ElementTree as et
 
 import pytest
 
+from django.contrib.auth.models import User
 from django.db.models import Max
 from django.urls import reverse
 
@@ -108,7 +109,12 @@ def test_create_catalog(db, client, username, password):
                 'catalogs': [catalog.id]
             }
             response = client.post(url, data, content_type='application/json')
-            assert response.status_code == status_map['create'][username], response.json()
+            expected_status_code = status_map['create'][username]
+            if expected_status_code == 201 and not User.objects.get(username=username).has_perm(
+                'questions.change_catalog_object', catalog
+            ):
+                expected_status_code = 403
+            assert response.status_code == expected_status_code, response.json()
 
             if response.status_code == 201:
                 new_instance = Section.objects.get(id=response.json().get('id'))

--- a/rdmo/questions/tests/test_viewset_section_multisite.py
+++ b/rdmo/questions/tests/test_viewset_section_multisite.py
@@ -2,7 +2,6 @@ import xml.etree.ElementTree as et
 
 import pytest
 
-from django.contrib.auth.models import User
 from django.db.models import Max
 from django.urls import reverse
 
@@ -109,12 +108,9 @@ def test_create_catalog(db, client, username, password):
                 'catalogs': [catalog.id]
             }
             response = client.post(url, data, content_type='application/json')
-            expected_status_code = status_map['create'][username]
-            if expected_status_code == 201 and not User.objects.get(username=username).has_perm(
-                'questions.change_catalog_object', catalog
-            ):
-                expected_status_code = 403
-            assert response.status_code == expected_status_code, response.json()
+            assert response.status_code == get_obj_perms_status_code(
+                catalog, username, 'create-parent'
+            ), response.json()
 
             if response.status_code == 201:
                 new_instance = Section.objects.get(id=response.json().get('id'))


### PR DESCRIPTION
### Motivation
- Prevent editors from creating child elements on parent elements that belong to another site by enforcing object-level change permission checks when parent relationships are supplied during creation.

### Description
- Add `validate_parent_field_permissions` to `ThroughModelSerializerMixin` that checks `self.Meta.parent_fields` on create and requires `change_<model>_object` permission on each supplied parent, raising `PermissionDenied` if missing.
- Import `PermissionDenied` from `rest_framework.exceptions` and wire the new validation into the serializer `validate` path so it runs before creation.
- Ensure `QuestionSerializer.validate` chains to the parent `validate` (`data = super().validate(data)`) so the parent-permission check runs for questions as well.
- Add `rdmo/questions/tests/test_viewset_parent_permissions_multisite.py` with parametrized multisite regression tests covering Catalog→Section, Section→Page, Page→QuestionSet/Question, QuestionSet→QuestionSet/Question scenarios where a bar.com editor attempts to attach a child to a foo.com parent and assert a `403` and unchanged parent through-relations.
- Update existing multisite create tests in `test_viewset_section_multisite.py`, `test_viewset_page_multisite.py`, `test_viewset_questionset_multisite.py`, and `test_viewset_question_multisite.py` to account for the new object-level permission enforcement when determining expected status codes.

### Testing
- Ran `ruff` on changed files and it passed without issues.
- Ran the new parent-permission test file with `pytest -q rdmo/questions/tests/test_viewset_parent_permissions_multisite.py` and it passed (`6 passed`).
- Executed the affected multisite viewset test suites (`rdmo/questions/tests/test_viewset_catalog_multisite.py`, `..._section_multisite.py`, `..._page_multisite.py`, `..._questionset_multisite.py`, `..._question_multisite.py`) together with the new parent-permission tests and observed all targeted tests passing (full exercised run completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a18593f96f8832d9e4db067c3a9f8b0)