### PR TITLE
Reduce DB queries for project resolve action and add performance test

### DIFF
--- a/rdmo/projects/tests/test_queries.py
+++ b/rdmo/projects/tests/test_queries.py
@@ -28,3 +28,35 @@ def test_queries(db, client, django_assert_max_num_queries, method, urlname, max
             response = client.post(url)
 
     assert response.status_code == 200
+
+
+@pytest.mark.performance
+def test_resolve_queries(db, client, django_assert_max_num_queries):
+    client.login(username='admin', password='admin')
+    url = reverse('v1-projects:project-resolve', args=[1])
+    data = [
+        {
+            'set_prefix': '',
+            'set_index': 0,
+            'element_type': 'questions',
+            'element_id': 104,
+        },
+        {
+            'set_prefix': '',
+            'set_index': 1,
+            'element_type': 'questions',
+            'element_id': 104,
+        },
+    ]
+
+    # Request authentication and permissions plus the project, the
+    # question-condition relation, the conditions, and the project values.
+    with django_assert_max_num_queries(9):
+        response = client.post(url, data, content_type='application/json')
+
+    assert response.status_code == 200
+    assert [
+        {key: value for key, value in result.items() if key != 'result'}
+        for result in response.json()
+    ] == data
+    assert all(isinstance(result['result'], bool) for result in response.json())

--- a/rdmo/projects/viewsets.py
+++ b/rdmo/projects/viewsets.py
@@ -128,7 +128,16 @@ class ProjectViewSet(ModelViewSet):
     filter_for_user = False  # flag for get_queryset to return only projects like for a regular user
 
     def get_queryset(self):
-        queryset = Project.objects.filter_user(self.request.user, self.filter_for_user).distinct().prefetch_related(
+        queryset = Project.objects.filter_user(self.request.user, self.filter_for_user).distinct()
+
+        # Resolving conditions only needs the project itself. In particular, it does
+        # not use the related objects or the last_changed annotation required by the
+        # project serializers. Avoid loading those for the resolve action, which is
+        # called frequently while an interview is being completed.
+        if self.action == 'resolve':
+            return queryset
+
+        queryset = queryset.prefetch_related(
             'snapshots',
             'views',
             Prefetch('memberships', queryset=Membership.objects.select_related('user'), to_attr='memberships_list')
@@ -201,7 +210,10 @@ class ProjectViewSet(ModelViewSet):
         set_prefix = request.GET.get('set_prefix')
         set_index = request.GET.get('set_index')
 
-        values = self.get_object().values.filter(snapshot_id=snapshot_id).select_related('attribute', 'option')
+        values = (
+            self.get_object().values.filter(snapshot_id=snapshot_id)
+            .select_related('attribute', 'option').order_by()
+        )
 
         page_id = request.GET.get('page')
         if page_id:
@@ -308,7 +320,7 @@ class ProjectViewSet(ModelViewSet):
         conditions = Condition.objects.select_related('source', 'target_option').in_bulk(condition_ids)
 
         # get all values of the project
-        values = project.values.filter(snapshot=None).select_related('attribute', 'option')
+        values = project.values.filter(snapshot=None).select_related('attribute', 'option').order_by()
 
         # second pass: resolve conditions
         for params in validated_data:


### PR DESCRIPTION
### Motivation
- The `resolve` action is called frequently during interviews and should avoid loading heavy related data and annotations to reduce database queries.
- Some queryset operations caused extra implicit work and ordering that increased query counts when resolving conditions.
- Add a focused performance test to prevent regressions in query counts for the resolve endpoint.

### Description
- Return early from `ProjectViewSet.get_queryset` for `self.action == 'resolve'` to skip prefetching and expensive annotations. 
- Add `.order_by()` to the project `values` query in `resolve` and to the values lookup earlier to avoid implicit ordering and extra queries. 
- Minor reformatting of the `values` queries to chain `select_related('attribute', 'option').order_by()`.
- Add a new performance test `test_resolve_queries` in `rdmo/projects/tests/test_queries.py` that posts to `v1-projects:project-resolve` and asserts a maximum of 9 DB queries and correct response shape.

### Testing
- Ran the project queries tests with `pytest rdmo/projects/tests/test_queries.py -q` which included the new `test_resolve_queries` test. 
- The test suite for the modified file completed successfully with the new performance test passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a68607d1338832da70abd00fa5fe933)